### PR TITLE
Fixed problem with uninstaller.jar merge content in case of installer path with "(1)"

### DIFF
--- a/izpack-core/src/main/java/com/izforge/izpack/merge/jar/JarMerge.java
+++ b/izpack-core/src/main/java/com/izforge/izpack/merge/jar/JarMerge.java
@@ -66,7 +66,7 @@ public class JarMerge extends AbstractMerge
     {
         this.jarPath = jarPath;
         this.mergeContent = mergeContent;
-        destination = FileUtil.convertUrlToFilePath(resource).replaceAll(this.jarPath, "").replaceAll("file:",
+        destination = FileUtil.convertUrlToFilePath(resource).replace(this.jarPath, "").replaceAll("file:",
                                                                                                       "").replaceAll(
                 "!/?", "").replaceAll("//", "/");
 


### PR DESCRIPTION
Fix for https://jira.codehaus.org/browse/IZPACK-1250
